### PR TITLE
fix: handle empty upstream repos in worktree pool

### DIFF
--- a/clients/git.go
+++ b/clients/git.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 )
+
+// ErrNoDefaultBranch is returned by GetDefaultBranch and GetDefaultBranchInWorktree
+// when the remote has no default branch (typically because the upstream repo is empty
+// with no commits — `git remote show origin` reports `HEAD branch: (unknown)` in that case).
+// Callers that perform staleness checks or refreshes should treat this as a no-op rather
+// than a failure, since an empty repo has no origin commits to compare against.
+var ErrNoDefaultBranch = errors.New("remote has no default branch (empty repo?)")
 
 type GitClient struct {
 	getRepoPath func() string // Function to get repository path (allows lazy evaluation)
@@ -490,6 +498,13 @@ func (g *GitClient) GetDefaultBranch() (string, error) {
 			}
 
 			branchName := strings.TrimSpace(parts[1])
+			// `git remote show origin` reports `HEAD branch: (unknown)` when the upstream
+			// repo has no commits yet. That's not a populated default branch, so signal
+			// it as ErrNoDefaultBranch and let callers skip work that needs an origin ref.
+			if branchName == "(unknown)" {
+				log.Info("📋 Remote has no default branch (upstream repo is empty)")
+				return "", ErrNoDefaultBranch
+			}
 			log.Info("✅ Default branch from remote: %s", branchName)
 			log.Info("📋 Completed successfully - got default branch from remote")
 			return branchName, nil
@@ -1798,6 +1813,10 @@ func (g *GitClient) GetDefaultBranchInWorktree(worktreePath string) (string, err
 			}
 
 			branchName := strings.TrimSpace(parts[1])
+			if branchName == "(unknown)" {
+				log.Info("📋 Remote has no default branch from worktree (upstream repo is empty)")
+				return "", ErrNoDefaultBranch
+			}
 			log.Info("✅ Default branch from worktree: %s", branchName)
 			return branchName, nil
 		}

--- a/clients/git_test.go
+++ b/clients/git_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -716,5 +717,119 @@ func TestWorktreeGitOperations(t *testing.T) {
 	}
 	if !hasChanges {
 		t.Error("Expected uncommitted changes after modifying file")
+	}
+}
+// setupTestRepoWithEmptyRemote creates a local clone of a bare empty remote.
+// The remote is a `git init --bare` with no commits, so `git remote show origin`
+// from the local clone reports `HEAD branch: (unknown)`.
+// Returns the local repo path and a cleanup function.
+func setupTestRepoWithEmptyRemote(t *testing.T) (string, func()) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "git-empty-remote-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+
+	remoteDir := filepath.Join(tmpDir, "remote.git")
+	localDir := filepath.Join(tmpDir, "local")
+
+	cmd := exec.Command("git", "init", "--bare", remoteDir)
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("Failed to init bare remote: %v", err)
+	}
+
+	cmd = exec.Command("git", "clone", remoteDir, localDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatalf("Failed to clone empty remote: %v\nOutput: %s", err, string(out))
+	}
+
+	cleanup := func() {
+		_ = os.RemoveAll(tmpDir)
+	}
+
+	return localDir, cleanup
+}
+
+func TestGetDefaultBranch_EmptyRemote(t *testing.T) {
+	repoPath, cleanup := setupTestRepoWithEmptyRemote(t)
+	defer cleanup()
+
+	client := NewGitClient()
+	client.SetRepoPathProvider(func() string { return repoPath })
+
+	_, err := client.GetDefaultBranch()
+	if err == nil {
+		t.Fatal("Expected error from GetDefaultBranch on empty remote, got nil")
+	}
+	if !errors.Is(err, ErrNoDefaultBranch) {
+		t.Errorf("Expected ErrNoDefaultBranch, got: %v", err)
+	}
+}
+
+func TestGetDefaultBranch_PopulatedRemote(t *testing.T) {
+	// Regression: make sure the empty-remote branch did not accidentally
+	// trigger ErrNoDefaultBranch for repos that DO have a default branch.
+	repoPath, cleanup := setupTestRepoWithEmptyRemote(t)
+	defer cleanup()
+
+	// Promote the empty remote to a populated one: create a commit on the local
+	// clone, push it to origin, then `git remote set-head origin --auto` so the
+	// remote tracks a real default branch.
+	configCmds := [][]string{
+		{"git", "config", "user.email", "test@example.com"},
+		{"git", "config", "user.name", "Test User"},
+	}
+	for _, args := range configCmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoPath
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to configure git: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write README: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "README.md"},
+		{"git", "commit", "-m", "init"},
+		{"git", "push", "-u", "origin", "HEAD"},
+		{"git", "remote", "set-head", "origin", "--auto"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("Failed to run %v: %v\nOutput: %s", args, err, string(out))
+		}
+	}
+
+	client := NewGitClient()
+	client.SetRepoPathProvider(func() string { return repoPath })
+
+	branch, err := client.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("Expected GetDefaultBranch to succeed on populated remote, got: %v", err)
+	}
+	if branch == "" || branch == "(unknown)" {
+		t.Errorf("Expected a real branch name, got %q", branch)
+	}
+}
+
+func TestGetDefaultBranchInWorktree_EmptyRemote(t *testing.T) {
+	// The worktree variant has the same `HEAD branch: (unknown)` parsing path
+	// and must also surface ErrNoDefaultBranch for empty upstreams.
+	repoPath, cleanup := setupTestRepoWithEmptyRemote(t)
+	defer cleanup()
+
+	client := NewGitClient()
+
+	_, err := client.GetDefaultBranchInWorktree(repoPath)
+	if err == nil {
+		t.Fatal("Expected error from GetDefaultBranchInWorktree on empty remote, got nil")
+	}
+	if !errors.Is(err, ErrNoDefaultBranch) {
+		t.Errorf("Expected ErrNoDefaultBranch, got: %v", err)
 	}
 }

--- a/usecases/worktree_pool.go
+++ b/usecases/worktree_pool.go
@@ -156,7 +156,12 @@ func (p *WorktreePool) Acquire(jobID, branchName string) (string, error) {
 	// Check staleness and refresh if needed
 	currentCommit, err := p.getCurrentOriginCommit()
 	if err != nil {
-		log.Warn("⚠️ Failed to get current origin commit for staleness check: %v", err)
+		if errors.Is(err, clients.ErrNoDefaultBranch) {
+			// Upstream is an empty repo — nothing to compare against, skip cleanly.
+			log.Info("📋 Skipping staleness check: upstream repo has no default branch (empty repo)")
+		} else {
+			log.Warn("⚠️ Failed to get current origin commit for staleness check: %v", err)
+		}
 	} else if pooledWT.BaseCommit != currentCommit {
 		log.Info("🔄 Worktree %s is stale, refreshing...", pooledWT.Path)
 		if err := p.refreshWorktreeAfterFetch(pooledWT.Path); err != nil {
@@ -258,7 +263,11 @@ func (p *WorktreePool) fillToTarget(ctx context.Context) {
 		}
 
 		if err := p.replenish(); err != nil {
-			log.Error("❌ Worktree pool: failed to replenish: %v", err)
+			if errors.Is(err, clients.ErrNoDefaultBranch) {
+				log.Info("📋 Worktree pool: upstream repo has no default branch (empty repo) — deferring pool fill")
+			} else {
+				log.Error("❌ Worktree pool: failed to replenish: %v", err)
+			}
 			return // back off on errors
 		}
 	}
@@ -371,7 +380,11 @@ func (p *WorktreePool) refreshStaleWorktrees() {
 
 	currentCommit, err := p.getCurrentOriginCommit()
 	if err != nil {
-		log.Warn("⚠️ Failed to get current origin commit for staleness check: %v", err)
+		if errors.Is(err, clients.ErrNoDefaultBranch) {
+			log.Info("📋 Skipping periodic staleness check: upstream repo has no default branch (empty repo)")
+		} else {
+			log.Warn("⚠️ Failed to get current origin commit for staleness check: %v", err)
+		}
 		return
 	}
 

--- a/usecases/worktree_pool_test.go
+++ b/usecases/worktree_pool_test.go
@@ -836,3 +836,95 @@ func TestReplenish_ResetsMainRepoBeforeCreatingWorktree(t *testing.T) {
 	pool.Stop()
 	_ = pool.CleanupPool()
 }
+// setupTestRepoEmptyRemote creates a local repo cloned from a bare empty remote.
+// Mirrors setupTestGitRepoWithRemote but stops short of creating any commits,
+// so `git remote show origin` reports `HEAD branch: (unknown)`.
+func setupTestRepoEmptyRemote(t *testing.T) (mainRepo string, worktreeBase string, cleanup func()) {
+	t.Helper()
+
+	remoteDir, err := os.MkdirTemp("", "git-empty-remote-*")
+	if err != nil {
+		t.Fatalf("Failed to create remote temp dir: %v", err)
+	}
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = remoteDir
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(remoteDir)
+		t.Fatalf("Failed to init bare remote: %v", err)
+	}
+
+	mainRepoDir, err := os.MkdirTemp("", "git-empty-main-*")
+	if err != nil {
+		_ = os.RemoveAll(remoteDir)
+		t.Fatalf("Failed to create main temp dir: %v", err)
+	}
+	cmd = exec.Command("git", "clone", remoteDir, mainRepoDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(remoteDir)
+		_ = os.RemoveAll(mainRepoDir)
+		t.Fatalf("Failed to clone empty remote: %v\nOutput: %s", err, string(out))
+	}
+
+	worktreeBaseDir, err := os.MkdirTemp("", "worktree-empty-base-*")
+	if err != nil {
+		_ = os.RemoveAll(remoteDir)
+		_ = os.RemoveAll(mainRepoDir)
+		t.Fatalf("Failed to create worktree base dir: %v", err)
+	}
+
+	cleanup = func() {
+		_ = os.RemoveAll(remoteDir)
+		_ = os.RemoveAll(mainRepoDir)
+		_ = os.RemoveAll(worktreeBaseDir)
+	}
+
+	return mainRepoDir, worktreeBaseDir, cleanup
+}
+
+// When the upstream repo has no commits, replenish must surface ErrNoDefaultBranch
+// (wrapped) so fillToTarget can back off without spamming error logs every cycle.
+// This is the path that previously produced "git rev-parse origin/(unknown)" spam
+// from a long-lived agent container pointed at an empty repo.
+func TestReplenish_EmptyRemote_PropagatesErrNoDefaultBranch(t *testing.T) {
+	mainRepo, worktreeBase, cleanup := setupTestRepoEmptyRemote(t)
+	defer cleanup()
+
+	gitClient := clients.NewGitClient()
+	gitClient.SetRepoPathProvider(func() string { return mainRepo })
+
+	pool := NewWorktreePool(gitClient, worktreeBase, 1)
+
+	err := pool.replenish()
+	if err == nil {
+		t.Fatal("Expected replenish to return an error on empty remote, got nil")
+	}
+	if !errors.Is(err, clients.ErrNoDefaultBranch) {
+		t.Errorf("Expected replenish error to wrap ErrNoDefaultBranch, got: %v", err)
+	}
+}
+
+// getCurrentOriginCommit must surface ErrNoDefaultBranch directly so callers
+// can branch on it (info-log + skip vs warn). refreshStaleWorktrees must not
+// crash for empty repos either.
+func TestGetCurrentOriginCommit_EmptyRemote(t *testing.T) {
+	mainRepo, worktreeBase, cleanup := setupTestRepoEmptyRemote(t)
+	defer cleanup()
+
+	gitClient := clients.NewGitClient()
+	gitClient.SetRepoPathProvider(func() string { return mainRepo })
+
+	pool := NewWorktreePool(gitClient, worktreeBase, 1)
+
+	_, err := pool.getCurrentOriginCommit()
+	if err == nil {
+		t.Fatal("Expected getCurrentOriginCommit to return an error on empty remote, got nil")
+	}
+	if !errors.Is(err, clients.ErrNoDefaultBranch) {
+		t.Errorf("Expected getCurrentOriginCommit error to be ErrNoDefaultBranch, got: %v", err)
+	}
+
+	// refreshStaleWorktrees must not panic on an empty repo. The pool is empty,
+	// so this is mainly a regression check that the (unknown) default-branch path
+	// no longer crashes or spams warnings.
+	pool.refreshStaleWorktrees()
+}


### PR DESCRIPTION
## Summary

\`GetDefaultBranch\` parses \`git remote show origin\` and was returning the literal string \`(unknown)\` when the upstream repo had no commits. Downstream callers then tried to resolve \`origin/(unknown)\` which fails:

\`\`\`
fatal: ambiguous argument 'origin/(unknown)': unknown revision or path not in the working tree
\`\`\`

The resulting warning was logged on every periodic staleness check (every 5 min) for any container pointed at an empty repo. We hit this in production on \`pres_test3-rubydev-eksecd\` (agents-freetier-v2) after the recent ccsaas fix unblocked the restart loop for empty-repo agents.

## Changes

- New sentinel \`clients.ErrNoDefaultBranch\`, returned from \`GetDefaultBranch\` and \`GetDefaultBranchInWorktree\` when \`HEAD branch:\` parses to \`(unknown)\`.
- In \`worktree_pool\`, all three call sites that consume \`getCurrentOriginCommit\` distinguish \`ErrNoDefaultBranch\` (info-log + skip cleanly) from real failures (warn). \`fillToTarget\` does the same when \`replenish\` returns the wrapped error, so the pool defers fill quietly instead of error-spamming.
- Existing \`fmt.Errorf("...: %w", err)\` wrapping is preserved, so \`errors.Is\` continues to work through the chain.

## Test plan

- [x] \`go build ./...\` succeeds
- [x] \`go test ./clients/ ./usecases/\` passes, including five new tests:
  - \`TestGetDefaultBranch_EmptyRemote\` — bare-remote clone returns \`ErrNoDefaultBranch\`
  - \`TestGetDefaultBranch_PopulatedRemote\` — regression: real default branches still resolve
  - \`TestGetDefaultBranchInWorktree_EmptyRemote\` — worktree variant handles the same case
  - \`TestReplenish_EmptyRemote_PropagatesErrNoDefaultBranch\` — \`replenish\` wraps and propagates the sentinel
  - \`TestGetCurrentOriginCommit_EmptyRemote\` — direct check + \`refreshStaleWorktrees\` does not panic
- [ ] After release + image roll: \`pres_test3-rubydev-eksecd\` stops logging \`Failed to get origin commit: origin/(unknown)\` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)