### PR TITLE
clients: bound hung WebFetch calls with a stall watchdog

### DIFF
--- a/clients/process.go
+++ b/clients/process.go
@@ -22,20 +22,30 @@ const WaitDelayAfterKill = 10 * time.Second
 // honours the NAIRI_MAX_SESSION_MS env var override.
 const DefaultSessionTimeout = 1 * time.Hour
 
+// DefaultWebFetchStallTimeout is the fallback maximum time a single Claude Code
+// WebFetch tool call may run without producing any further stream output before
+// nairid kills the (hung) agent process. Claude Code has no built-in WebFetch
+// timeout — a hung fetch stalls the whole turn indefinitely until the much
+// larger SessionTimeout fires (see anthropics/claude-code#34565, closed as "not
+// planned") — so nairid enforces one here. Prefer WebFetchStallTimeout() at
+// runtime, which honours the NAIRI_WEBFETCH_STALL_MS env var override.
+const DefaultWebFetchStallTimeout = 60 * time.Second
+
 // BlockedEnvVars lists environment variables that should never be passed to agent processes.
 // These contain sensitive credentials or nairid-internal config that agents should not see.
 var BlockedEnvVars = map[string]bool{
-	"NAIRI_API_KEY":        true,
-	"NAIRI_WS_API_URL":     true,
-	"NAIRI_MAX_SESSION_MS": true, // nairid-only config (CLI session timeout)
-	"EKSEC_API_KEY":        true, // Legacy env var
-	"EKSEC_WS_API_URL":     true, // Legacy env var
-	"EKSEC_MAX_SESSION_MS": true, // Legacy env var
-	"CCAGENT_API_KEY":      true, // Legacy env var
-	"CCAGENT_WS_API_URL":   true, // Legacy env var
-	"AGENT_EXEC_USER":      true,
-	"AGENT_HTTP_PROXY":     true, // This is for nairid to read, not for agents
-	"AGENT_MCP_PROXY":      true, // This is for nairid to read, not for agents
+	"NAIRI_API_KEY":           true,
+	"NAIRI_WS_API_URL":        true,
+	"NAIRI_MAX_SESSION_MS":    true, // nairid-only config (CLI session timeout)
+	"NAIRI_WEBFETCH_STALL_MS": true, // nairid-only config (WebFetch stall watchdog)
+	"EKSEC_API_KEY":           true, // Legacy env var
+	"EKSEC_WS_API_URL":        true, // Legacy env var
+	"EKSEC_MAX_SESSION_MS":    true, // Legacy env var
+	"CCAGENT_API_KEY":         true, // Legacy env var
+	"CCAGENT_WS_API_URL":      true, // Legacy env var
+	"AGENT_EXEC_USER":         true,
+	"AGENT_HTTP_PROXY":        true, // This is for nairid to read, not for agents
+	"AGENT_MCP_PROXY":         true, // This is for nairid to read, not for agents
 }
 
 // SessionTimeout returns the per-CLI-session timeout used to bound a single
@@ -64,6 +74,32 @@ func SessionTimeout() time.Duration {
 	if err != nil || ms <= 0 {
 		log.Printf("[SessionTimeout] invalid %s=%q, falling back to default %s", source, raw, DefaultSessionTimeout)
 		return DefaultSessionTimeout
+	}
+
+	return time.Duration(ms) * time.Millisecond
+}
+
+// WebFetchStallTimeout returns the maximum time a single Claude Code WebFetch
+// tool call may run without emitting any further stream output before nairid
+// treats the agent process as hung and kills it. This bounds the "hung WebFetch"
+// failure mode that Claude Code itself does not guard against.
+//
+// Resolution order:
+//  1. NAIRI_WEBFETCH_STALL_MS — integer number of milliseconds (>= 0)
+//  2. DefaultWebFetchStallTimeout (60s) when unset or invalid
+//
+// A value of 0 disables the watchdog entirely. The value is read on every call
+// so a deployment can pick up changes by restarting the daemon.
+func WebFetchStallTimeout() time.Duration {
+	raw := os.Getenv("NAIRI_WEBFETCH_STALL_MS")
+	if raw == "" {
+		return DefaultWebFetchStallTimeout
+	}
+
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || ms < 0 {
+		log.Printf("[WebFetchStallTimeout] invalid NAIRI_WEBFETCH_STALL_MS=%q, falling back to default %s", raw, DefaultWebFetchStallTimeout)
+		return DefaultWebFetchStallTimeout
 	}
 
 	return time.Duration(ms) * time.Millisecond

--- a/clients/streaming.go
+++ b/clients/streaming.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync"
+	"time"
 )
 
 // CommandError wraps a command execution error with its captured output.
@@ -24,9 +26,27 @@ func (e *CommandError) Unwrap() error {
 	return e.Err
 }
 
+// lineStartsWebFetch reports whether a Claude Code stream-json line represents an
+// assistant message that kicks off a WebFetch tool call. Claude Code emits these
+// as compact JSON, e.g. {"type":"tool_use","name":"WebFetch",...}. A hung WebFetch
+// produces no further output until it (never) returns, so this marks the point
+// after which the stall watchdog starts counting.
+func lineStartsWebFetch(line []byte) bool {
+	return bytes.Contains(line, []byte(`"type":"tool_use"`)) &&
+		bytes.Contains(line, []byte(`"name":"WebFetch"`))
+}
+
 // RunCommandStreaming executes a command, reading stdout line-by-line and calling onLine
 // for each non-empty line. It accumulates the full output and returns it on success.
 // This replaces cmd.CombinedOutput() to enable real-time progress streaming.
+//
+// It additionally runs a "WebFetch stall" watchdog: whenever a stream line starts a
+// WebFetch tool call, a timer is armed for WebFetchStallTimeout(). If no further
+// output arrives before it fires, the agent's whole process group is killed (via the
+// same cmd.Cancel machinery used for context timeouts). This bounds the hung-WebFetch
+// failure mode that Claude Code does not guard against — without it, a stuck fetch
+// silently stalls the entire turn until the far larger SessionTimeout fires, and the
+// user's message gets no response. Any subsequent stream line disarms the watchdog.
 func RunCommandStreaming(ctx context.Context, cmd *exec.Cmd, onLine ProgressCallback) (string, error) {
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -38,6 +58,48 @@ func RunCommandStreaming(ctx context.Context, cmd *exec.Cmd, onLine ProgressCall
 		return "", fmt.Errorf("failed to start command: %w", err)
 	}
 
+	stallTimeout := WebFetchStallTimeout()
+
+	// Watchdog state guarded by mu. armedAt is the zero value when disarmed;
+	// otherwise it is the time the pending WebFetch tool call was observed.
+	var (
+		mu      sync.Mutex
+		armedAt time.Time
+		stalled bool
+	)
+	stopWatch := make(chan struct{})
+	if stallTimeout > 0 {
+		go func() {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stopWatch:
+					return
+				case <-ticker.C:
+					mu.Lock()
+					hung := !armedAt.IsZero() && time.Since(armedAt) >= stallTimeout
+					if hung {
+						stalled = true
+						armedAt = time.Time{}
+					}
+					mu.Unlock()
+					if hung {
+						// Kill the whole process group; cmd.WaitDelay guarantees
+						// Wait() below won't block on an orphaned pipe. This unblocks
+						// the ReadBytes call in the loop below.
+						if cmd.Cancel != nil {
+							_ = cmd.Cancel()
+						} else if cmd.Process != nil {
+							_ = cmd.Process.Kill()
+						}
+						return
+					}
+				}
+			}
+		}()
+	}
+
 	var fullOutput strings.Builder
 	reader := bufio.NewReader(stdout)
 	for {
@@ -45,18 +107,44 @@ func RunCommandStreaming(ctx context.Context, cmd *exec.Cmd, onLine ProgressCall
 		if len(line) > 0 {
 			fullOutput.Write(line)
 			trimmed := bytes.TrimSpace(line)
-			if len(trimmed) > 0 && onLine != nil {
-				onLine(trimmed)
+			if len(trimmed) > 0 {
+				if onLine != nil {
+					onLine(trimmed)
+				}
+				if stallTimeout > 0 {
+					// Any line disarms a pending WebFetch; a line that itself starts
+					// a WebFetch (re)arms the watchdog from now.
+					mu.Lock()
+					if lineStartsWebFetch(trimmed) {
+						armedAt = time.Now()
+					} else {
+						armedAt = time.Time{}
+					}
+					mu.Unlock()
+				}
 			}
 		}
 		if err != nil {
 			break
 		}
 	}
+	close(stopWatch)
 
-	if err := cmd.Wait(); err != nil {
+	waitErr := cmd.Wait()
+
+	mu.Lock()
+	wasStalled := stalled
+	mu.Unlock()
+	if wasStalled {
 		return "", &CommandError{
-			Err:    err,
+			Err:    fmt.Errorf("WebFetch stalled: no stream output for %s — a WebFetch tool call appears to have hung", stallTimeout),
+			Output: fullOutput.String(),
+		}
+	}
+
+	if waitErr != nil {
+		return "", &CommandError{
+			Err:    waitErr,
 			Output: fullOutput.String(),
 		}
 	}

--- a/clients/streaming_test.go
+++ b/clients/streaming_test.go
@@ -144,3 +144,104 @@ func TestRunCommandStreaming_TimeoutKillsProcessTree(t *testing.T) {
 		t.Errorf("RunCommandStreaming took %v, expected under %v (process group kill may not be working)", elapsed, maxExpected)
 	}
 }
+
+func TestLineStartsWebFetch(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"webfetch tool_use", `{"type":"tool_use","name":"WebFetch","input":{"url":"https://x.com"}}`, true},
+		{"bash tool_use", `{"type":"tool_use","name":"Bash","input":{"command":"ls"}}`, false},
+		{"assistant text mentioning WebFetch", `{"type":"text","text":"I will use WebFetch now"}`, false},
+		{"webfetch name without tool_use type", `{"type":"text","name":"WebFetch"}`, false},
+		{"result line", `{"type":"result","is_error":false}`, false},
+	}
+	for _, tc := range cases {
+		if got := lineStartsWebFetch([]byte(tc.line)); got != tc.want {
+			t.Errorf("%s: lineStartsWebFetch(%q) = %v, want %v", tc.name, tc.line, got, tc.want)
+		}
+	}
+}
+
+// TestRunCommandStreaming_WebFetchStallKillsHungProcess simulates the production
+// incident: the agent emits a WebFetch tool_use event and then hangs forever. The
+// stall watchdog must kill the process group quickly and return a stall CommandError
+// instead of blocking until the (much larger) session timeout.
+func TestRunCommandStreaming_WebFetchStallKillsHungProcess(t *testing.T) {
+	original := os.Getenv("AGENT_EXEC_USER")
+	defer func() { _ = os.Setenv("AGENT_EXEC_USER", original) }()
+	_ = os.Unsetenv("AGENT_EXEC_USER")
+	t.Setenv("NAIRI_WEBFETCH_STALL_MS", "1000")
+
+	// Generous ctx timeout so we prove the *watchdog* (not the ctx) fired.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	webfetch := `{"type":"tool_use","name":"WebFetch","input":{"url":"https://example.com"}}`
+	cmd := BuildAgentCommandWithContext(ctx, "sh", "-c",
+		"printf '%s\\n' '"+webfetch+"'; sleep 300 & wait")
+
+	start := time.Now()
+	_, err := RunCommandStreaming(ctx, cmd, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected stall error for hung WebFetch")
+	}
+	cmdErr, ok := err.(*CommandError)
+	if !ok {
+		t.Fatalf("expected *CommandError, got %T", err)
+	}
+	if !strings.Contains(cmdErr.Error(), "WebFetch stalled") {
+		t.Errorf("expected WebFetch stall error, got: %v", cmdErr.Error())
+	}
+	// Watchdog (1s) + tick granularity + WaitDelay should be well under the 60s ctx.
+	if elapsed > WaitDelayAfterKill+10*time.Second {
+		t.Errorf("RunCommandStreaming took %v, expected the watchdog to kill much sooner", elapsed)
+	}
+}
+
+// TestRunCommandStreaming_NonWebFetchNotKilled proves the watchdog is WebFetch-
+// specific: a non-WebFetch tool call that runs longer than the stall timeout must
+// NOT be killed, so ordinary long-running tools (e.g. Bash builds) are unaffected.
+func TestRunCommandStreaming_NonWebFetchNotKilled(t *testing.T) {
+	original := os.Getenv("AGENT_EXEC_USER")
+	defer func() { _ = os.Setenv("AGENT_EXEC_USER", original) }()
+	_ = os.Unsetenv("AGENT_EXEC_USER")
+	t.Setenv("NAIRI_WEBFETCH_STALL_MS", "1000")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	bash := `{"type":"tool_use","name":"Bash","input":{"command":"sleep"}}`
+	cmd := BuildAgentCommandWithContext(ctx, "sh", "-c",
+		"printf '%s\\n' '"+bash+"'; sleep 3; printf 'done\\n'")
+
+	out, err := RunCommandStreaming(ctx, cmd, nil)
+	if err != nil {
+		t.Fatalf("non-WebFetch tool should not be killed by the watchdog, got error: %v", err)
+	}
+	if !strings.Contains(out, "done") {
+		t.Errorf("expected output to contain 'done', got: %q", out)
+	}
+}
+
+// TestRunCommandStreaming_WebFetchDisarmedByOutput ensures a WebFetch that keeps
+// producing output (or completes) before the stall window is not killed.
+func TestRunCommandStreaming_WebFetchDisarmedByOutput(t *testing.T) {
+	t.Setenv("NAIRI_WEBFETCH_STALL_MS", "1000")
+
+	webfetch := `{"type":"tool_use","name":"WebFetch","input":{"url":"https://example.com"}}`
+	result := `{"type":"result","is_error":false}`
+	cmd := exec.CommandContext(context.Background(), "sh", "-c",
+		"printf '%s\\n' '"+webfetch+"'; printf '%s\\n' '"+result+"'")
+
+	out, err := RunCommandStreaming(context.Background(), cmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "result") {
+		t.Errorf("expected output to contain result line, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Problem

Claude Code's `WebFetch` tool has **no timeout**. When a fetch hangs (e.g. a slow/blocking host that never returns), the whole agent turn stalls — Claude emits the `WebFetch` tool_use event and then goes completely silent. nairid keeps waiting until the **1-hour session timeout** fires, and because the turn produced no final assistant message, **the user's message gets no response at all** (not even an error). From the user's side the agent simply went dark.

This is an upstream limitation, closed as "not planned": [anthropics/claude-code#34565](https://github.com/anthropics/claude-code/issues/34565) (see also #8980). Since we can't set a WebFetch timeout in Claude Code's settings (no such knob exists), we bound it in the layer we control.

### Real incident this fixes
An agent received a "scrape the web for info on these cameras" message with 2 attachments. Claude fired two parallel `WebFetch` calls that hung, stalled for the full hour, then the processor exited with no reply. The user waited with zero response.

## Fix

`RunCommandStreaming` now runs a lightweight **WebFetch stall watchdog**:

- When a stream line starts a `WebFetch` tool call, a timer is armed for `WebFetchStallTimeout()` (default **60s**, override via `NAIRI_WEBFETCH_STALL_MS`, `0` disables).
- If no further stream output arrives before it fires, the agent's **whole process group is killed** via the existing `cmd.Cancel` machinery (`WaitDelay` still guards the pipe), and a `WebFetch stalled: …` `CommandError` is returned.
- That error flows through the normal error path, so the user gets a prompt error message (~60s) instead of an hour of silence.
- The watchdog is **WebFetch-specific** and **disarms on the very next stream line**, so ordinary long-running tools (Bash builds, etc.) are unaffected. Non-Claude CLIs never emit the WebFetch marker, so they're untouched.

## Tests

`clients/streaming_test.go`:
- `TestLineStartsWebFetch` — marker detection (tool_use+WebFetch vs Bash vs plain text).
- `TestRunCommandStreaming_WebFetchStallKillsHungProcess` — arms WebFetch then hangs → killed quickly with a stall error (proves the watchdog, not the ctx, fired).
- `TestRunCommandStreaming_NonWebFetchNotKilled` — a Bash tool running longer than the stall window is **not** killed.
- `TestRunCommandStreaming_WebFetchDisarmedByOutput` — a WebFetch that keeps producing output is not killed.

All existing `clients` tests pass; `go build ./...`, `go vet ./clients/`, and `gofmt` clean.

## Notes / follow-ups
- Default is intentionally conservative (60s). Operators can tune or disable via `NAIRI_WEBFETCH_STALL_MS`.
- Separately worth hardening: ensure the timeout/error fallback message reliably reaches the thread even during a WebSocket reconnect (in the incident, no system message was delivered). Not addressed here.