### PR TITLE
fix(opencode): treat empty agent turns as empty result, not a hard error

### DIFF
--- a/services/opencode/opencode_messages.go
+++ b/services/opencode/opencode_messages.go
@@ -307,7 +307,15 @@ func ExtractOpenCodeResult(messages []OpenCodeMessage) (string, error) {
 		return "Completed: " + strings.Join(toolSummaries, "; "), nil
 	}
 
-	return "", fmt.Errorf("no text message found")
+	// The step finished with neither text nor any tool work — an empty turn.
+	// This happens when the model exhausts its output budget on reasoning and is
+	// truncated before emitting an answer (step_finish reason "length"), or when
+	// the provider returns a completely empty/aborted response (reason "unknown",
+	// zero tokens). Treat it as a valid-but-empty result rather than a hard error:
+	// returning an empty output lets the job complete and flow into the backend's
+	// existing "(agent sent empty response)" fallback, instead of silently dropping
+	// the user's message on the error path.
+	return "", nil
 }
 
 // extractToolSummary generates a human-readable summary from a tool use message

--- a/services/opencode/opencode_messages_test.go
+++ b/services/opencode/opencode_messages_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestMapOpenCodeOutputToMessages(t *testing.T) {
 	tests := []struct {
-		name           string
-		input          string
-		expectedCount  int
-		expectedTypes  []string
-		expectError    bool
+		name          string
+		input         string
+		expectedCount int
+		expectedTypes []string
+		expectError   bool
 	}{
 		{
 			name: "successful parsing of complete response",
@@ -229,25 +229,27 @@ func TestExtractOpenCodeResult(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name:           "returns error when no text messages",
+			// Empty turn: model emitted no text and did no tool work (e.g. step_finish
+			// reason "length" after burning the output budget on reasoning, or reason
+			// "unknown" with zero tokens). This must NOT be a hard error — it returns an
+			// empty result so the job completes and the backend's empty-response fallback
+			// takes over instead of the message being silently dropped on the error path.
+			name:           "returns empty result when no text messages",
 			input:          `{"type":"step_start","timestamp":1759406013703,"sessionID":"ses_123","part":{}}`,
 			expectedResult: "",
-			expectError:    true,
-			errorContains:  "no text message found",
+			expectError:    false,
 		},
 		{
-			name:           "returns error for empty input",
+			name:           "returns empty result for empty input",
 			input:          "",
 			expectedResult: "",
-			expectError:    true,
-			errorContains:  "no text message found",
+			expectError:    false,
 		},
 		{
-			name:           "ignores text message with empty text",
+			name:           "returns empty result for text message with empty text",
 			input:          `{"type":"text","timestamp":1759406015783,"sessionID":"ses_123","part":{"type":"text","text":""}}`,
 			expectedResult: "",
-			expectError:    true,
-			errorContains:  "no text message found",
+			expectError:    false,
 		},
 		{
 			name: "returns opencode error for raw error output",
@@ -529,32 +531,33 @@ func TestExtractOpenCodeResult_ToolUseFallback(t *testing.T) {
 			name: "ignores read tool (not an action)",
 			input: `{"type":"tool_use","timestamp":1767690268885,"sessionID":"ses_123","part":{"tool":"read","state":{"status":"completed","title":"README.md"}}}
 {"type":"step_finish","timestamp":1767690269077,"sessionID":"ses_123","part":{}}`,
+			// Read is not an actionable tool, so there is no summary to fall back to.
+			// The turn is effectively empty → empty result, not an error.
 			expectedResult: "",
-			expectError:    true,
-			errorContains:  "no text message found",
+			expectError:    false,
 		},
 		{
-			name: "ignores incomplete tool operations",
+			name:  "ignores incomplete tool operations",
 			input: `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"edit","state":{"status":"pending","title":"README.md"}}}`,
+			// No completed tool work and no text → empty result, not an error.
 			expectedResult: "",
-			expectError:    true,
-			errorContains:  "no text message found",
+			expectError:    false,
 		},
 		{
-			name: "handles edit without diff stats",
-			input: `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"edit","state":{"status":"completed","title":"config.yaml"}}}`,
+			name:           "handles edit without diff stats",
+			input:          `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"edit","state":{"status":"completed","title":"config.yaml"}}}`,
 			expectedResult: "Completed: edited config.yaml",
 			expectError:    false,
 		},
 		{
-			name: "handles write tool",
-			input: `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"write","state":{"status":"completed","title":"newfile.txt"}}}`,
+			name:           "handles write tool",
+			input:          `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"write","state":{"status":"completed","title":"newfile.txt"}}}`,
 			expectedResult: "Completed: created newfile.txt",
 			expectError:    false,
 		},
 		{
-			name: "handles bash tool",
-			input: `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"bash","state":{"status":"completed"}}}`,
+			name:           "handles bash tool",
+			input:          `{"type":"tool_use","timestamp":1767690438167,"sessionID":"ses_123","part":{"tool":"bash","state":{"status":"completed"}}}`,
 			expectedResult: "Completed: ran command",
 			expectError:    false,
 		},

--- a/services/opencode/opencode_test.go
+++ b/services/opencode/opencode_test.go
@@ -61,11 +61,16 @@ func TestOpenCodeService_StartNewConversation(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "no text message in response",
-			prompt:      "Hello",
-			mockOutput:  `{"type":"step_start","timestamp":1759406013703,"sessionID":"ses_456","part":{}}`,
-			mockError:   nil,
-			expectError: true,
+			// Empty turn (no text, no tool work) is not a hard error — it returns an
+			// empty output so the job completes and the backend's empty-response
+			// fallback takes over instead of the message being dropped.
+			name:            "no text message in response",
+			prompt:          "Hello",
+			mockOutput:      `{"type":"step_start","timestamp":1759406013703,"sessionID":"ses_456","part":{}}`,
+			mockError:       nil,
+			expectError:     false,
+			expectedOutput:  "",
+			expectedSession: "ses_456",
 		},
 		{
 			name:   "empty prompt",
@@ -607,4 +612,3 @@ func TestOpenCodeService_AgentName(t *testing.T) {
 		t.Errorf("Expected agent name %q, got %q", expectedName, agentName)
 	}
 }
-


### PR DESCRIPTION
## Problem

`ExtractOpenCodeResult` returned `fmt.Errorf("no text message found")` whenever a step finished with **no text and no actionable tool work**. nairid surfaced that as a `SystemMessage` error (`nairid encountered error: failed to extract OpenCode result: no text message found`) and dropped the user's message with **zero assistant reply** — a silent drop.

This turns out to be a normal, non-fatal outcome for reasoning models running under OpenCode. Two observed empty-turn modes (from raw session logs):

- **`reason:"length"`** — the model burns its entire output budget on reasoning tokens and is truncated *before* emitting any answer text (e.g. `reasoning:31999`, `output:1`).
- **`reason:"unknown"` + zero tokens** — the provider returns a completely empty/aborted response (`input:0/output:0`).

Neither is a harness failure, but both produced a hard error and a dropped message. This was low-rate but persistent on OpenCode agents.

## Fix

Return `"", nil` for the empty-turn case instead of an error. An empty output flows through to an empty `AssistantMessage`, which the backend **already** maps to its existing `(agent sent empty response)` fallback — so the job completes with a visible reply instead of dropping the message on the error path.

Genuine failures are unaffected: OpenCode API errors (bad key, insufficient balance) and crashes / raw error output still return errors as before. This only changes the "produced literally nothing" branch.

The existing tool-summary fallback (#68) only covered "did tool work but no final text"; this closes the remaining "produced nothing at all" gap. Applies to all OpenCode agents, not any single deployment.

## Tests

Updated the affected unit tests in `opencode_messages_test.go` and `opencode_test.go` to assert empty-result-not-error. `go test ./services/opencode/` passes; full `go build ./...` and `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
